### PR TITLE
fixed the link for contact page

### DIFF
--- a/src/lab/index.html
+++ b/src/lab/index.html
@@ -65,7 +65,7 @@
 			                    <li class="page-scroll menu-li " >
 			                        <a href="http://vlabs.ac.in#partner" class="menu-a" >PARTNERS</a>
 			                    </li><li class="page-scroll menu-li " >
-			                        <a href="http://vlabs.ac.in#contact" class="menu-a" >CONTACT</a>
+			                        <a href="http://vlab.co.in/contact-us" class="menu-a" >CONTACT</a>
 			                    </li>
 			                </ul>
 			                


### PR DESCRIPTION
now the link for contact page directs to " contact us " instead of home 
fixes #83